### PR TITLE
Added "spiral" and "center path" options for the Arc path

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -41,7 +41,7 @@ Bezier curves are made form a start point, an end point each with a control poin
 Arc
 ---
 
-Exampe: animate along an arc
+Example: animate along an arc
 
 <pre>
   
@@ -61,6 +61,77 @@ $("my_elem").animate({path : new $.path.arc(arc_params)})
 * start is the angle of the start point. 0 is "North", measured clockwise
 * end is the angle of the start point. 0 is "North", measured clockwise
 * dir is the direction to move in. Only required if not obvious from start and end (e.g. if start is 100, end is 30, but you want to animate clockwise)
+
+### Advanced Arcs ###
+
+Example: add a spiral to the arc
+
+<pre>
+  var arc_params = {
+    center: [285, 185],
+    spiral: [1, 100],
+    start: 30,
+    end: 200,
+    dir: -1
+  }
+
+  $('my_elem').animate({path : new $.path.arc(arc_params)})
+</pre>
+
+Example: use another path as the center of the arc
+
+<pre>
+  var bezier_params = {
+    start: { 
+      x: 185, 
+      y: 185, 
+      angle: 10
+    },  
+    end: { 
+      x:540,
+      y:110, 
+      angle: -10, 
+      length: 0.25
+    }
+  }
+
+  var arc_params = {
+    center: new $.path.bezier(bezier_params),
+    radius: 100,
+    start: 30,
+    end: 200,
+    dir: -1
+  }
+
+  $('my_elem').animate({path : new $.path.arc(arc_params)})
+</pre>
+
+Example: combine both the spiral and center paths
+<pre>
+  var bezier_params = {
+    start: { 
+      x: 185, 
+      y: 185, 
+      angle: 10
+    },  
+    end: { 
+      x:540,
+      y:110, 
+      angle: -10, 
+      length: 0.25
+    }
+  }
+
+  var arc_params = {
+    center: new $.path.bezier(bezier_params),
+    radius: [1, 100],
+    start: 30,
+    end: 200,
+    dir: -1
+  }
+
+  $('my_elem').animate({path : new $.path.arc(arc_params)})
+</pre>
 
 Other Paths
 ----

--- a/jquery.path.js
+++ b/jquery.path.js
@@ -76,40 +76,64 @@
     for ( var i in params ) {
       this[i] = params[i];
     }
-
     this.dir = this.dir || 1;
 
     while ( this.start > this.end && this.dir > 0 ) {
-      this.start -= 360;
+        this.start -= 360;
     }
 
     while ( this.start < this.end && this.dir < 0 ) {
-      this.start += 360;
+        this.start += 360;
+    }
+
+    if(this.spiral) {
+        if(this.spiral.constructor == Array && this.spiral.length > 1) {
+            this.radiusStart = this.spiral[0] || 1;
+            this.radiusEnd = this.spiral[1] || 1;
+        } else {
+            this.radiusStart = 1;
+            this.radiusEnd = (this.spiral.constructor == Array ? this.spiral[0] : this.spiral) || 1;
+        }
+        this.radius = this.radiusStart;
+        this.radiusDiff = Math.abs(this.radiusEnd - this.radiusStart);
+    }
+
+    if(this.center.constructor.constructor == Function) {
+        this.centerPath = this.center;
     }
 
     this.css = function(p) {
       var a = ( this.start * (p ) + this.end * (1-(p )) ) * Math.PI / 180,
-        css = {};
+              css = {};
 
       if (rotate) {
         css.prevX = this.x;
         css.prevY = this.y;
       }
-      css.x = this.x = ( Math.sin(a) * this.radius + this.center[0] +.5 )|0;
-      css.y = this.y = ( Math.cos(a) * this.radius + this.center[1] +.5 )|0;
+
+      var centerX;
+      var centerY;
+      if(this.centerPath) {
+        var centerPosition = this.centerPath.css(p);
+        centerX = centerPosition.x;
+        centerY = centerPosition.y;
+
+      } else {
+        centerX = this.center[0];
+        centerY = this.center[1];
+      }
+
+      css.x = this.x = ( Math.sin(a) * this.radius + centerX +.5 )|0;
+      css.y = this.y = ( Math.cos(a) * this.radius + centerY +.5 )|0;
       css.left = css.x + "px";
       css.top = css.y + "px";
+
+      if(this.spiral) {
+        this.radius = this.radiusStart + (this.radiusDiff - (this.radiusDiff * p));
+      }
+
       return css;
     };
-  };
-
-  $.fx.step.path = function(fx) {
-    var css = fx.end.css( 1 - fx.pos );
-    if ( css.prevX != null ) {
-      $.cssHooks.transform.set( fx.elem, "rotate(" + Math.atan2(css.prevY - css.y, css.prevX - css.x) + ")" );
-    }
-    fx.elem.style.top = css.top;
-    fx.elem.style.left = css.left;
-  };
+  }
 
 })(jQuery);


### PR DESCRIPTION
I added two optional features when using the Arc path:
- specify a "spiral" option instead of "radius". The array should have two numeric elements, representing the starting and ending radius, respecively
- specify another path object for the "center" option. It will be used the calculate the center for each step of the path
