### PR TITLE
Added "spiral" and "center path" options for the Arc path, rotation support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -41,7 +41,7 @@ Bezier curves are made form a start point, an end point each with a control poin
 Arc
 ---
 
-Exampe: animate along an arc
+Example: animate along an arc
 
 <pre>
   
@@ -61,6 +61,77 @@ $("my_elem").animate({path : new $.path.arc(arc_params)})
 * start is the angle of the start point. 0 is "North", measured clockwise
 * end is the angle of the start point. 0 is "North", measured clockwise
 * dir is the direction to move in. Only required if not obvious from start and end (e.g. if start is 100, end is 30, but you want to animate clockwise)
+
+### Advanced Arcs ###
+
+Example: add a spiral to the arc
+
+<pre>
+  var arc_params = {
+    center: [285, 185],
+    spiral: [1, 100],
+    start: 30,
+    end: 200,
+    dir: -1
+  }
+
+  $('my_elem').animate({path : new $.path.arc(arc_params)})
+</pre>
+
+Example: use another path as the center of the arc
+
+<pre>
+  var bezier_params = {
+    start: { 
+      x: 185, 
+      y: 185, 
+      angle: 10
+    },  
+    end: { 
+      x:540,
+      y:110, 
+      angle: -10, 
+      length: 0.25
+    }
+  }
+
+  var arc_params = {
+    center: new $.path.bezier(bezier_params),
+    radius: 100,
+    start: 30,
+    end: 200,
+    dir: -1
+  }
+
+  $('my_elem').animate({path : new $.path.arc(arc_params)})
+</pre>
+
+Example: combine both the spiral and center paths
+<pre>
+  var bezier_params = {
+    start: { 
+      x: 185, 
+      y: 185, 
+      angle: 10
+    },  
+    end: { 
+      x:540,
+      y:110, 
+      angle: -10, 
+      length: 0.25
+    }
+  }
+
+  var arc_params = {
+    center: new $.path.bezier(bezier_params),
+    radius: [1, 100],
+    start: 30,
+    end: 200,
+    dir: -1
+  }
+
+  $('my_elem').animate({path : new $.path.arc(arc_params)})
+</pre>
 
 Other Paths
 ----

--- a/README.markdown
+++ b/README.markdown
@@ -43,8 +43,7 @@ Arc
 
 Example: animate along an arc
 
-<pre>
-  
+<pre>  
 var arc_params = {
     center: [285,185],	
 		radius: 100,	
@@ -67,7 +66,7 @@ $("my_elem").animate({path : new $.path.arc(arc_params)})
 Example: add a spiral to the arc
 
 <pre>
-  var arc_params = {
+var arc_params = {
     center: [285, 185],
     spiral: [1, 100],
     start: 30,
@@ -81,7 +80,7 @@ Example: add a spiral to the arc
 Example: use another path as the center of the arc
 
 <pre>
-  var bezier_params = {
+var bezier_params = {
     start: { 
       x: 185, 
       y: 185, 
@@ -95,7 +94,7 @@ Example: use another path as the center of the arc
     }
   }
 
-  var arc_params = {
+var arc_params = {
     center: new $.path.bezier(bezier_params),
     radius: 100,
     start: 30,
@@ -103,12 +102,12 @@ Example: use another path as the center of the arc
     dir: -1
   }
 
-  $('my_elem').animate({path : new $.path.arc(arc_params)})
+$('my_elem').animate({path : new $.path.arc(arc_params)})
 </pre>
 
 Example: combine both the spiral and center paths
 <pre>
-  var bezier_params = {
+var bezier_params = {
     start: { 
       x: 185, 
       y: 185, 
@@ -122,7 +121,7 @@ Example: combine both the spiral and center paths
     }
   }
 
-  var arc_params = {
+var arc_params = {
     center: new $.path.bezier(bezier_params),
     radius: [1, 100],
     start: 30,
@@ -130,7 +129,58 @@ Example: combine both the spiral and center paths
     dir: -1
   }
 
-  $('my_elem').animate({path : new $.path.arc(arc_params)})
+$('my_elem').animate({path : new $.path.arc(arc_params)})
+</pre>
+
+Rotation
+---
+Rotation can be added to any path by specifying a rotator.
+
+Example: keep the top of the element facing forward on the path
+
+<pre>
+var bezier_params = {
+    start: { 
+      x: 185, 
+      y: 185, 
+      angle: 10
+    },  
+    end: { 
+      x:540,
+      y:110, 
+      angle: -10, 
+      length: 0.25
+    },
+    rotator: new $.path.rotators.followPath()
+  }
+  
+$("my_elem").animate({path : new $.path.bezier(bezier_params)})
+</pre>
+
+Example: make the element spin
+<pre>
+var spin_params = {
+    start: 30,
+    end: 200,
+    dir: -1
+  }
+
+var bezier_params = {
+    start: { 
+      x: 185, 
+      y: 185, 
+      angle: 10
+    },  
+    end: { 
+      x:540,
+      y:110, 
+      angle: -10, 
+      length: 0.25
+    },
+    rotator: new $.path.rotators.spin(spin_params)
+  }
+  
+$("my_elem").animate({path : new $.path.bezier(bezier_params)})
 </pre>
 
 Other Paths

--- a/jquery.path.js
+++ b/jquery.path.js
@@ -1,16 +1,16 @@
 /*
  * jQuery css bezier animation support -- Jonah Fox
- * version 0.0.1
+ * version 0.0.2
  * Released under the MIT license.
  */
 /*
-  var path = $.path.bezier({
-    start: {x:10, y:10, angle: 20, length: 0.3},
-    end:   {x:20, y:30, angle: -20, length: 0.2}
-  })
-  $("myobj").animate({path: path}, duration)
+ var path = $.path.bezier({
+ start: {x:10, y:10, angle: 20, length: 0.3},
+ end:   {x:20, y:30, angle: -20, length: 0.2}
+ })
+ $("myobj").animate({path: path}, duration)
 
-*/
+ */
 
 ;(function($){
 
@@ -73,67 +73,71 @@
   };
 
   $.path.arc = function(params, rotate) {
-    for ( var i in params ) {
-      this[i] = params[i];
-    }
-    this.dir = this.dir || 1;
+      for ( var i in params ) {
+        this[i] = params[i];
+      }
+      this.dir = this.dir || 1;
 
-    while ( this.start > this.end && this.dir > 0 ) {
+      while ( this.start > this.end && this.dir > 0 ) {
         this.start -= 360;
-    }
+      }
 
-    while ( this.start < this.end && this.dir < 0 ) {
+      while ( this.start < this.end && this.dir < 0 ) {
         this.start += 360;
-    }
+      }
 
-    if(this.spiral) {
+      if(this.spiral) {
         if(this.spiral.constructor == Array && this.spiral.length > 1) {
-            this.radiusStart = this.spiral[0] || 1;
-            this.radiusEnd = this.spiral[1] || 1;
+          this.radiusStart = this.spiral[0] || 1;
+          this.radiusEnd = this.spiral[1] || 1;
         } else {
-            this.radiusStart = 1;
-            this.radiusEnd = (this.spiral.constructor == Array ? this.spiral[0] : this.spiral) || 1;
+          this.radiusStart = 1;
+          this.radiusEnd = (this.spiral.constructor == Array ? this.spiral[0] : this.spiral) || 1;
         }
         this.radius = this.radiusStart;
         this.radiusDiff = Math.abs(this.radiusEnd - this.radiusStart);
-    }
+      }
 
-    if(this.center.constructor.constructor == Function) {
+      if(this.center.css && this.center.css.constructor == Function) {
         this.centerPath = this.center;
-    }
-
-    this.css = function(p) {
-      var a = ( this.start * (p ) + this.end * (1-(p )) ) * Math.PI / 180,
-              css = {};
-
-      if (rotate) {
-        css.prevX = this.x;
-        css.prevY = this.y;
+        this.center = [0,0];
       }
 
-      var centerX;
-      var centerY;
-      if(this.centerPath) {
-        var centerPosition = this.centerPath.css(p);
-        centerX = centerPosition.x;
-        centerY = centerPosition.y;
+      this.css = function(p) {
+        var a = ( this.start * (p ) + this.end * (1-(p )) ) * Math.PI / 180,
+          css = {};
 
-      } else {
-        centerX = this.center[0];
-        centerY = this.center[1];
-      }
+        if (rotate) {
+          css.prevX = this.x;
+          css.prevY = this.y;
+        }
 
-      css.x = this.x = ( Math.sin(a) * this.radius + centerX +.5 )|0;
-      css.y = this.y = ( Math.cos(a) * this.radius + centerY +.5 )|0;
-      css.left = css.x + "px";
-      css.top = css.y + "px";
+        if(this.centerPath) {
+          var pos = this.centerPath.css(p);
+          this.center[0] = pos.x;
+          this.center[1] = pos.y;
+        }
 
-      if(this.spiral) {
-        this.radius = this.radiusStart + (this.radiusDiff - (this.radiusDiff * p));
-      }
+        css.x = this.x = ( Math.sin(a) * this.radius + this.center[0] +.5 )|0;
+        css.y = this.y = ( Math.cos(a) * this.radius + this.center[1] +.5 )|0;
+        css.left = css.x + "px";
+        css.top = css.y + "px";
 
-      return css;
+        if(this.spiral) {
+          this.radius = this.radiusStart + (this.radiusDiff - (this.radiusDiff * p));
+        }
+
+        return css;
     };
-  }
+  };
+
+  $.fx.step.path = function(fx) {
+    var css = fx.end.css( 1 - fx.pos );
+    if ( css.prevX != null ) {
+      $.cssHooks.transform.set( fx.elem, "rotate(" + Math.atan2(css.prevY - css.y, css.prevX - css.x) + ")" );
+    }
+    fx.elem.style.top = css.top;
+    fx.elem.style.left = css.left;
+  };
 
 })(jQuery);

--- a/jquery.path.js
+++ b/jquery.path.js
@@ -76,40 +76,64 @@
     for ( var i in params ) {
       this[i] = params[i];
     }
-
     this.dir = this.dir || 1;
 
     while ( this.start > this.end && this.dir > 0 ) {
-      this.start -= 360;
+        this.start -= 360;
     }
 
     while ( this.start < this.end && this.dir < 0 ) {
-      this.start += 360;
+        this.start += 360;
+    }
+
+    if(this.spiral) {
+        if(this.spiral.constructor == Array && this.spiral.length > 1) {
+            this.radiusStart = this.spiral[0] || 1;
+            this.radiusEnd = this.spiral[1] || 1;
+        } else {
+            this.radiusStart = 1;
+            this.radiusEnd = (this.spiral.constructor == Array ? this.spiral[0] : this.spiral) || 1;
+        }
+        this.radius = this.radiusStart;
+        this.radiusDiff = Math.abs(this.radiusEnd - this.radiusStart);
+    }
+
+    if(this.center.constructor.constructor == Function) {
+        this.centerPath = this.center;
     }
 
     this.css = function(p) {
       var a = ( this.start * (p ) + this.end * (1-(p )) ) * Math.PI / 180,
-        css = {};
+              css = {};
 
       if (rotate) {
         css.prevX = this.x;
         css.prevY = this.y;
       }
-      css.x = this.x = ( Math.sin(a) * this.radius + this.center[0] +.5 )|0;
-      css.y = this.y = ( Math.cos(a) * this.radius + this.center[1] +.5 )|0;
+
+      var centerX;
+      var centerY;
+      if(this.centerPath) {
+        var centerPosition = this.centerPath.css(p);
+        centerX = centerPosition.x;
+        centerY = centerPosition.y;
+
+      } else {
+        centerX = this.center[0];
+        centerY = this.center[1];
+      }
+
+      css.x = this.x = ( Math.sin(a) * this.radius + centerX +.5 )|0;
+      css.y = this.y = ( Math.cos(a) * this.radius + centerY +.5 )|0;
       css.left = css.x + "px";
       css.top = css.y + "px";
+
+      if(this.spiral) {
+        this.radius = this.radiusStart + (this.radiusDiff - (this.radiusDiff * p));
+      }
+
       return css;
     };
-  };
-
-  $.fx.step.path = function(fx) {
-    var css = fx.end.css( 1 - fx.pos );
-    if ( css.prevX != null ) {
-      $.cssHooks.transform.set( fx.elem, "rotate(" + Math.atan2(css.prevY - css.y, css.prevX - css.x) + ")" );
-    }
-    fx.elem.style.top = css.top;
-    fx.elem.style.left = css.left;
-  };
+  }
 
 })(jQuery);

--- a/jquery.path.js
+++ b/jquery.path.js
@@ -1,20 +1,26 @@
 /*
  * jQuery css bezier animation support -- Jonah Fox
- * version 0.0.2
+ * version 0.0.3
  * Released under the MIT license.
  */
 /*
- var path = $.path.bezier({
- start: {x:10, y:10, angle: 20, length: 0.3},
- end:   {x:20, y:30, angle: -20, length: 0.2}
- })
- $("myobj").animate({path: path}, duration)
+  var path = $.path.bezier({
+    start: {x:10, y:10, angle: 20, length: 0.3},
+    end:   {x:20, y:30, angle: -20, length: 0.2}
+  })
+  $("myobj").animate({path: path}, duration)
 
- */
+*/
 
 ;(function($){
 
-  $.path = {};
+  $.path = {
+    isPath: function(path) {
+      return path &&
+        path.css &&
+        path.css.constructor == Function;
+    }
+  };
 
   var V = {
     rotate: function(p, degrees) {
@@ -34,7 +40,9 @@
     }
   };
 
-  $.path.bezier = function( params, rotate ) {
+  $.path.bezier = function(params) {
+    this.x = params.start.x;
+    this.y = params.start.y;
     params.start = $.extend( {angle: 0, length: 0.3333}, params.start );
     params.end = $.extend( {angle: 0, length: 0.3333}, params.end );
 
@@ -60,10 +68,6 @@
     /* p from 0 to 1 */
     this.css = function(p) {
       var f1 = this.f1(p), f2 = this.f2(p), f3 = this.f3(p), f4=this.f4(p), css = {};
-      if (rotate) {
-        css.prevX = this.x;
-        css.prevY = this.y;
-      }
       css.x = this.x = ( this.p1[0]*f1 + this.p2[0]*f2 +this.p3[0]*f3 + this.p4[0]*f4 +.5 )|0;
       css.y = this.y = ( this.p1[1]*f1 + this.p2[1]*f2 +this.p3[1]*f3 + this.p4[1]*f4 +.5 )|0;
       css.left = css.x + "px";
@@ -72,70 +76,116 @@
     };
   };
 
-  $.path.arc = function(params, rotate) {
-      for ( var i in params ) {
-        this[i] = params[i];
-      }
-      this.dir = this.dir || 1;
+  $.path.arc = function(params) {
+    for ( var i in params ) {
+      this[i] = params[i];
+    }
+    this.dir = this.dir || 1;
 
-      while ( this.start > this.end && this.dir > 0 ) {
-        this.start -= 360;
+    while ( this.start > this.end && this.dir > 0 ) {
+      this.start -= 360;
+    }
+
+    while ( this.start < this.end && this.dir < 0 ) {
+      this.start += 360;
+    }
+
+    if(this.spiral) {
+      if(this.spiral.constructor == Array && this.spiral.length > 1) {
+        this.radiusStart = this.spiral[0] || 1;
+        this.radiusEnd = this.spiral[1] || 1;
+      } else {
+        this.radiusStart = 1;
+        this.radiusEnd = (this.spiral.constructor == Array ? this.spiral[0] : this.spiral) || 1;
+      }
+      this.radius = this.radiusStart;
+      this.radiusDiff = Math.abs(this.radiusEnd - this.radiusStart);
+    }
+
+    if($.path.isPath(this.center)) {
+      this.centerPath = this.center;
+      this.center = [0,0];
+    }
+
+    this.css = function(p) {
+      var a = ( this.start * (p ) + this.end * (1-(p )) ) * Math.PI / 180,
+        css = {};
+
+      if(this.centerPath) {
+        var pos = this.centerPath.css(p);
+        this.center[0] = pos.x;
+        this.center[1] = pos.y;
       }
 
-      while ( this.start < this.end && this.dir < 0 ) {
-        this.start += 360;
-      }
+      css.x = this.x = ( Math.sin(a) * this.radius + this.center[0] +.5 )|0;
+      css.y = this.y = ( Math.cos(a) * this.radius + this.center[1] +.5 )|0;
+      css.left = css.x + "px";
+      css.top = css.y + "px";
 
       if(this.spiral) {
-        if(this.spiral.constructor == Array && this.spiral.length > 1) {
-          this.radiusStart = this.spiral[0] || 1;
-          this.radiusEnd = this.spiral[1] || 1;
-        } else {
-          this.radiusStart = 1;
-          this.radiusEnd = (this.spiral.constructor == Array ? this.spiral[0] : this.spiral) || 1;
-        }
-        this.radius = this.radiusStart;
-        this.radiusDiff = Math.abs(this.radiusEnd - this.radiusStart);
+        this.radius = this.radiusStart + (this.radiusDiff - (this.radiusDiff * p));
       }
 
-      if(this.center.css && this.center.css.constructor == Function) {
-        this.centerPath = this.center;
-        this.center = [0,0];
-      }
+      return css;
+    };
+  };
 
-      this.css = function(p) {
-        var a = ( this.start * (p ) + this.end * (1-(p )) ) * Math.PI / 180,
-          css = {};
+  // rotators
+  $.path.rotators = {
+    isRotator: function(rotator) {
+      return rotator &&
+        rotator.rotate &&
+        rotator.rotate.constructor == Function &&
+        rotator.unit;
+    },
+    units: {
+      degrees: 'deg',
+      gradians: 'grad',
+      radians: 'rad',
+      turns: 'turn'
+    }
+  };
 
-        if (rotate) {
-          css.prevX = this.x;
-          css.prevY = this.y;
-        }
+  $.path.rotators.followPath = function() {
+    this.unit = $.path.rotators.units.radians;
+    this.rotate = function(p, css, prevState) {
+      return Math.atan2(prevState.y - css.y, prevState.x - css.x);
+    };
+  };
 
-        if(this.centerPath) {
-          var pos = this.centerPath.css(p);
-          this.center[0] = pos.x;
-          this.center[1] = pos.y;
-        }
+  $.path.rotators.spin = function (params) {
+    this.unit = $.path.rotators.units.degrees;
+    for ( var i in params ) {
+      this[i] = params[i];
+    }
+    this.dir = this.dir || 1;
 
-        css.x = this.x = ( Math.sin(a) * this.radius + this.center[0] +.5 )|0;
-        css.y = this.y = ( Math.cos(a) * this.radius + this.center[1] +.5 )|0;
-        css.left = css.x + "px";
-        css.top = css.y + "px";
+    while ( this.start > this.end && this.dir > 0 ) {
+      this.start -= 360;
+    }
 
-        if(this.spiral) {
-          this.radius = this.radiusStart + (this.radiusDiff - (this.radiusDiff * p));
-        }
+    while ( this.start < this.end && this.dir < 0 ) {
+      this.start += 360;
+    }
 
-        return css;
+    this.diff = this.end - this.start;
+
+    this.rotate = function(p, css, prevCss) {
+      var pos = this.start - (this.diff - (this.diff * p));
+      return pos % 360;
     };
   };
 
   $.fx.step.path = function(fx) {
+    var prevState = $.extend(true, {}, fx.end);
     var css = fx.end.css( 1 - fx.pos );
-    if ( css.prevX != null ) {
-      $.cssHooks.transform.set( fx.elem, "rotate(" + Math.atan2(css.prevY - css.y, css.prevX - css.x) + ")" );
+
+    // note: rotation requires the transform CSS hook (https://github.com/brandonaaron/jquery-cssHooks/blob/master/transform.js)
+    if($.path.rotators.isRotator(fx.end.rotator) && $.cssHooks.transform) {
+      var rotation = fx.end.rotator.rotate(1 - fx.pos, css, prevState);
+      $.cssHooks.transform.set( fx.elem, "rotate(" + rotation + fx.end.rotator.unit + ")" );
     }
+
     fx.elem.style.top = css.top;
     fx.elem.style.left = css.left;
   };


### PR DESCRIPTION
I added two optional features when using the Arc path:
- specify a "spiral" option instead of "radius". The array should have two numeric elements, representing the starting and ending radius, respecively
- specify another path object for the "center" option. It will be used the calculate the center for each step of the path

I also added better support for rotating the element.
- _IMPORTANT_: Rotation requires that the "transform" css hook is present (from https://github.com/brandonaaron/jquery-cssHooks/blob/master/transform.js). This is a carryover from the existing rotation functionality, which doesn't document the requirement. I'm not sure if there's a better way to support this.
- The existing rotation algorithm was refactored into the 'followPath' rotator.
- Added a 'spin' rotator that works similar to the arc path.
- Rotators should be added to the $.path.rotators object
- A rotator must:
  - have a 'rotate' function that returns a numeric value
  - have a 'unit' property whose value is one of the supported css transform-rotate units (deg, rad, grad, turn). These values are also available from the $.path.rotators.units object
- in the step function, if the path object ('end') contains a valid rotator and the transform css hook is detected, it will call the 'rotate' function and set the css transform to rotate to the value and unit specified by the rotator. it passes in 'p', the position; 'css', the css object generated by the path object; and 'prevState', the state of the path object before the css() function was called.
